### PR TITLE
Use RouteGroup to power Router

### DIFF
--- a/response.go
+++ b/response.go
@@ -7,11 +7,11 @@ import (
 )
 
 // NoData is a placeholder type for the default action creator.
-type NoData = struct{}
+type NoData struct{}
 
 // WithNoData is a convenience function for creating a NoData type for use with
 // groups and routers.
-func WithNoData(rootRequest RootRequest) NoData {
+func WithNoData(rootRequest *RootRequest) NoData {
 	return NoData{}
 }
 

--- a/route.go
+++ b/route.go
@@ -21,7 +21,7 @@ type Route[C any] struct {
 
 // Given a request, returns true if the route matches the request and false if
 // not.
-func (r *Route[C]) IsMatch(req RootRequest) (bool, map[string]string) {
+func (r *Route[C]) IsMatch(req *RootRequest) (bool, map[string]string) {
 	if r.Method != req.Request().Method {
 		return false, nil
 	}

--- a/route_test.go
+++ b/route_test.go
@@ -94,7 +94,7 @@ func TestRouteMatching(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			req := httptest.NewRequest(tc.reqMethod, tc.reqPath, nil)
-			root := RootRequest{originalRequest: req}
+			root := &RootRequest{originalRequest: req}
 			route := newRoute(tc.routeMethod, tc.routePath, func(context.Context, *Request[NoData]) Response {
 				return OK()
 			})

--- a/router_test.go
+++ b/router_test.go
@@ -122,7 +122,7 @@ func TestRouter_MissingRoute_WithHandler(t *testing.T) {
 }
 
 func TestCustomActionType(t *testing.T) {
-	router := New[*MyData](func(rootRequest RootRequest) *MyData {
+	router := New[*MyData](func(rootRequest *RootRequest) *MyData {
 		return &MyData{Value: 1}
 	})
 
@@ -262,7 +262,7 @@ func TestBefore_EarlyExit(t *testing.T) {
 }
 
 func TestBefore_DifferentDataType(t *testing.T) {
-	router := New(func(rootRequest RootRequest) *MyData {
+	router := New(func(rootRequest *RootRequest) *MyData {
 		return &MyData{Value: 1}
 	})
 
@@ -317,7 +317,7 @@ func GenericBefore[T any](ctx context.Context, req *Request[T], next Next) Respo
 }
 
 func Test_BeforeModifiesData(t *testing.T) {
-	router := New(func(rootRequest RootRequest) *MyData {
+	router := New(func(rootRequest *RootRequest) *MyData {
 		return &MyData{Value: 1}
 	})
 


### PR DESCRIPTION
This simplifies a lot of the code by removing the duplication between
RouteGroup and Router by composing the routing logic in Router using a
RouteGroup of `RouteGroup[NoData, T]`.
