### PR TITLE
Support passing context to New, Group, SubRouter

### DIFF
--- a/group_test.go
+++ b/group_test.go
@@ -85,7 +85,7 @@ func TestGroup_Subgroup(t *testing.T) {
 		next(rw, r)
 	})
 
-	group := Group[NoData, MyData, registerable[NoData]](router, func(r *Request[NoData]) MyData {
+	group := Group(router, func(r *Request[NoData]) MyData {
 		return MyData{Value: 1}
 	})
 


### PR DESCRIPTION
It's useful to pass a context to the data creator function like when
you need to a context to make a database query or implement tracing.

This adds new *WithContext functions for New, Group, and SubRouter that
accept the current context and expect the new context to be returned.
